### PR TITLE
feat: allow running custom sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If you do **NOT** want world backups and/or purging of backups then set the valu
 
 Env var 'CUSTOM_JAR_PATH' is optional and allows you to define a specific jar to run, if not specified then the latest Mojang Minecraft jar will be used.
 
+Env var 'CUSTOM_STARTUP_SCRIPT' is optional and allows you to run a specific sh script instead of a jar file
+
 Env vars 'JAVA_INITIAL_HEAP_SIZE' value and 'JAVA_MAX_HEAP_SIZE' values must be a multiple of 1024 and greater than 2MB.
 
 User ID (PUID) and Group ID (PGID) can be found by issuing the following command for the user you want to run the container as:-

--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -43,7 +43,7 @@ fi
 ####
 
 # define pacman packages
-pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre-openjdk-headless screen rsync"
+pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre-openjdk-headless screen rsync which"
 
 # install compiled packages using pacman
 if [[ ! -z "${pacman_packages}" ]]; then

--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -118,10 +118,18 @@ function start_minecraft() {
 	# create logs sub folder to store screen output from console
 	mkdir -p /config/minecraft/logs
 
+  # allow custom scripts instead of forced jar - useful to run modern modpacks
+  if [[ -z "${CUSTOM_STARTUP_SCRIPT}" ]]; then
+    run_script="java -Xms${JAVA_INITIAL_HEAP_SIZE} -Xmx${JAVA_MAX_HEAP_SIZE} -XX:ParallelGCThreads=${JAVA_MAX_THREADS} ${java_log4j_mitigation} -jar ${CUSTOM_JAR_PATH} nogui"
+  else
+    chmod +x "${CUSTOM_STARTUP_SCRIPT}"
+    run_script="${CUSTOM_STARTUP_SCRIPT}"
+  fi
+
 	# run screen attached to minecraft (daemonized, non-blocking) to allow users to run commands in minecraft console
 	echo "[info] Starting Minecraft Java process..."
 	set -x
-	screen -L -Logfile '/config/minecraft/logs/screen.log' -d -S minecraft -m bash -c "cd /config/minecraft && java -Xms${JAVA_INITIAL_HEAP_SIZE} -Xmx${JAVA_MAX_HEAP_SIZE} -XX:ParallelGCThreads=${JAVA_MAX_THREADS} ${java_log4j_mitigation} -jar ${CUSTOM_JAR_PATH} nogui"
+	screen -L -Logfile '/config/minecraft/logs/screen.log' -d -S minecraft -m bash -c "cd /config/minecraft && ${run_script}"
 	set +x
 	echo "[info] Minecraft Java process is running"
 	if [[ ! -z "${STARTUP_CMD}" ]]; then


### PR DESCRIPTION
This is needed in order to automate the usage of some modern modpacks, it also resolves #5 because you can create a custom start.sh with whatever java args you want.

Examples of what this allows:
[Automatic Server Updates - Enigmatica Modpacks](https://wiki.enigmatica.net/main/help-desk/guides/automatic-server-updates)
[All The Mods](https://github.com/AllTheMods/ATM-6/wiki/Installing-A-Server)
