### PR TITLE
add a healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,7 @@ ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
 # set permissions
 #################
 
+HEALTHCHECK (nc -z localhost 8222 && nc -z localhost 25565) || exit 1
+
 # run script to set uid, gid and permissions
 CMD ["/bin/bash", "/usr/local/bin/init.sh"]

--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -43,7 +43,7 @@ fi
 ####
 
 # define pacman packages
-pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre-openjdk-headless screen rsync"
+pacman_packages="jre8-openjdk-headless jre11-openjdk-headless jre-openjdk-headless screen rsync gnu-netcat"
 
 # install compiled packages using pacman
 if [[ ! -z "${pacman_packages}" ]]; then


### PR DESCRIPTION
Motivation: If the container provides a healthcheck, users can use a project like https://hub.docker.com/r/willfarrell/autoheal/ to automatically restart the container if it should be unhealthy.